### PR TITLE
Returning progress as a float within 0 and 1 so that no assumption is…

### DIFF
--- a/include/task.hpp
+++ b/include/task.hpp
@@ -91,7 +91,7 @@ namespace io1::progress
     void set_finish_callback(finish_callback_t f) noexcept { report_.finish = f; };
 
   private:
-    [[nodiscard]] auto calculate_progress() const noexcept { return (100.f * progress_) / target_; };
+    [[nodiscard]] auto calculate_progress() const noexcept { return static_cast<float>(progress_) / target_; };
 
     void report_progress() const noexcept
     {

--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(range_semantic)
 
   auto const report = [&index, &started, &finished](float progress)
   {
-    constexpr float expected[] = {20.f, 40.f, 60.f, 80.f, 100.f};
+    constexpr float expected[] = {0.2f, 0.4f, 0.6f, 0.8f, 1.f};
     BOOST_CHECK_EQUAL(progress, expected[index]);
     BOOST_CHECK(started);
     BOOST_CHECK(!finished);


### PR DESCRIPTION
… made on client code formatting needs and hence no overhead.