### PR TITLE
Further work to prepare sub tasking and control on how often a task reports progression

### DIFF
--- a/include/task.hpp
+++ b/include/task.hpp
@@ -49,7 +49,6 @@ namespace io1::progress
     [[nodiscard]] bool report_now() const noexcept { return true; };
   };
 
-
   // PRECISION controls the minimum progress increment that will be reported
   // MIN_REPORT_INTERVAL_MS says that some time must have ellasped between two reports.
   template <unsigned int PRECISION = 100, unsigned int MIN_REPORT_INTERVAL_MS = 100>
@@ -116,7 +115,7 @@ namespace io1::progress
     report_functions report_;
   };
 
-  using pc_task = basic_task<100,0>;
+  using pc_task = basic_task<100, 0>;
 
   template <typename ITERATOR>
   class task_iterator_wrapper

--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -10,7 +10,7 @@ namespace
   {
   public:
     explicit progression_check(std::vector<unsigned int> expected_steps, std::string expected_name = std::string())
-        : expected_steps_(expected_steps), expected_name_(expected_name) {};
+        : expected_steps_(expected_steps), expected_name_(expected_name){};
 
     [[nodiscard]] operator io1::progress::report_functions()
     {
@@ -49,7 +49,7 @@ namespace
     bool started_{false};
     bool finished_{false};
   };
-}
+} // namespace
 
 BOOST_AUTO_TEST_CASE(default_construction)
 {
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(default_construction)
 
 BOOST_AUTO_TEST_CASE(basic_incrementations_and_success)
 {
-  progression_check check({20 ,40, 80, 100});
+  progression_check check({20, 40, 80, 100});
 
   {
     io1::progress::pc_task t(check);
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(range_semantic)
   progression_check check({20, 40, 60, 80, 100});
 
   {
-    io1::progress::basic_task<100,100> t(check);
+    io1::progress::basic_task<100, 100> t(check);
 
     std::vector<int> const vec = {1, 2, 3, 4, 5};
 

--- a/test/test_task.cpp
+++ b/test/test_task.cpp
@@ -4,6 +4,52 @@
 
 #define BOOST_TEST_MODULE io1::progress test
 #include <boost/test/unit_test.hpp>
+namespace
+{
+  class progression_check
+  {
+  public:
+    explicit progression_check(std::vector<unsigned int> expected_steps, std::string expected_name = std::string())
+        : expected_steps_(expected_steps), expected_name_(expected_name) {};
+
+    [[nodiscard]] operator io1::progress::report_functions()
+    {
+      auto const start = [this](std::string_view name)
+      {
+        BOOST_CHECK_EQUAL(name, expected_name_);
+        started_ = true;
+      };
+
+      auto const report = [this](unsigned int progress)
+      { BOOST_CHECK_EQUAL(progress, expected_steps_[progress_index_++]); };
+
+      auto const finish = [this](bool success)
+      {
+        BOOST_CHECK_EQUAL(success, expected_steps_.back() == 100);
+        finished_ = true;
+      };
+
+      return {start, report, finish};
+    };
+
+    auto started() const { return started_; };
+    auto finished() const { return finished_; };
+    auto progressed() const
+    {
+      auto const temp = progress_index_ > last_progress_index_;
+      last_progress_index_ = progress_index_;
+      return temp;
+    }
+
+  private:
+    std::vector<unsigned int> expected_steps_;
+    std::string expected_name_;
+    mutable size_t last_progress_index_{0};
+    size_t progress_index_{0};
+    bool started_{false};
+    bool finished_{false};
+  };
+}
 
 BOOST_AUTO_TEST_CASE(default_construction)
 {
@@ -11,7 +57,8 @@ BOOST_AUTO_TEST_CASE(default_construction)
   auto const finished = [&flag](bool) { flag = true; };
 
   {
-    io1::progress::basic_task<100> t;
+    // unstarted tasks do not report on destruction
+    io1::progress::pc_task t;
     t.set_finish_callback(finished);
   }
 
@@ -19,53 +66,116 @@ BOOST_AUTO_TEST_CASE(default_construction)
   return;
 }
 
+BOOST_AUTO_TEST_CASE(basic_incrementations_and_success)
+{
+  progression_check check({20 ,40, 80, 100});
+
+  {
+    io1::progress::pc_task t(check);
+    BOOST_CHECK(!check.started());
+    BOOST_CHECK(!check.finished());
+    BOOST_CHECK(!check.progressed());
+
+    t.start(5);
+    BOOST_CHECK(check.started());
+    BOOST_CHECK(!check.finished());
+    BOOST_CHECK(!check.progressed());
+
+    ++t;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+
+    ++t;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+
+    t += 2;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+
+    ++t;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+  }
+
+  BOOST_CHECK(!check.progressed());
+  BOOST_CHECK(check.finished());
+
+  return;
+}
+
+BOOST_AUTO_TEST_CASE(basic_incrementations_and_failure)
+{
+  progression_check check({20, 40, 80});
+
+  {
+    io1::progress::pc_task t(check);
+    BOOST_CHECK(!check.started());
+    BOOST_CHECK(!check.finished());
+    BOOST_CHECK(!check.progressed());
+
+    t.start(5);
+    BOOST_CHECK(check.started());
+    BOOST_CHECK(!check.finished());
+    BOOST_CHECK(!check.progressed());
+
+    ++t;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+
+    ++t;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+
+    t += 2;
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
+  }
+
+  BOOST_CHECK(!check.progressed());
+  BOOST_CHECK(check.finished());
+
+  return;
+}
+
 BOOST_AUTO_TEST_CASE(range_semantic)
 {
-  size_t index = 0;
-  bool started = false;
-  bool finished = false;
-
-  std::vector<int> const vec = {1, 2, 3, 4, 5};
-
-  auto const start = [&index, &started, &finished](std::string_view name)
-  {
-    BOOST_CHECK(std::empty(name));
-    BOOST_CHECK_EQUAL(0, index);
-    BOOST_CHECK(!started);
-    BOOST_CHECK(!finished);
-    started = true;
-  };
-
-  auto const report = [&index, &started, &finished](float progress)
-  {
-    constexpr float expected[] = {0.2f, 0.4f, 0.6f, 0.8f, 1.f};
-    BOOST_CHECK_EQUAL(progress, expected[index]);
-    BOOST_CHECK(started);
-    BOOST_CHECK(!finished);
-    ++index;
-  };
-
-  auto const finish = [&index, &started, &finished, &vec](bool success)
-  {
-    BOOST_CHECK_EQUAL(vec.size(), index);
-    BOOST_CHECK(success);
-    BOOST_CHECK(started);
-    BOOST_CHECK(!finished);
-    finished = true;
-  };
+  progression_check check({20, 40, 60, 80, 100});
 
   {
-    io1::progress::basic_task<100> t({start, report, finish});
-    size_t i = 0;
+    io1::progress::basic_task<100,100> t(check);
+
+    std::vector<int> const vec = {1, 2, 3, 4, 5};
+
+    BOOST_CHECK(!check.started());
+    BOOST_CHECK(!check.progressed());
+    BOOST_CHECK(!check.finished());
+
     for (auto const & v : vec | t)
     {
+      static size_t i = 0;
+      if (0 == i)
+      {
+        BOOST_CHECK(check.started());
+        BOOST_CHECK(!check.progressed());
+        BOOST_CHECK(!check.finished());
+      }
+      else
+      {
+        BOOST_CHECK(check.progressed());
+        BOOST_CHECK(!check.finished());
+      }
+
       BOOST_CHECK_EQUAL(v, vec[i++]);
       std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
+
+    BOOST_CHECK(check.progressed());
+    BOOST_CHECK(!check.finished());
   }
 
-  BOOST_CHECK(started);
-  BOOST_CHECK(finished);
+  BOOST_CHECK(!check.progressed());
+  BOOST_CHECK(check.finished());
 
   return;
 }


### PR DESCRIPTION
renamed REPORT_INTERVAL_MS to MIN_REPORT_INTERVAL. Changed the progression return type from float to unsigned int to that a task knows when it is expected to report a progress (everytime the unsigned int is incremented, as opposed to everytime the task is increment, which may happen too often. Added a template parameter PRECISION to control how often the unsigned int is incremented. Refactored the unit tests to make them more readable and added two tests not related to range-for mode, which is only prototyped as of now.